### PR TITLE
Update bloodType.xml

### DIFF
--- a/Defs/bloodType.xml
+++ b/Defs/bloodType.xml
@@ -112,7 +112,6 @@
                 <li Class="BloodTypes.IngestionOutcomeDoer_DonateBlood">
                     <hediffDef>GotBlood</hediffDef>
                     <severity>0.15</severity>
-                    <toleranceChemical>Blood</toleranceChemical>
                 </li>
             </outcomeDoers>
         </ingestible>
@@ -122,7 +121,6 @@
                 <rotDestroys>true</rotDestroys>
             </li>
             <li Class="CompProperties_Drug">
-                <chemical>Blood</chemical>
                 <addictiveness>0.00</addictiveness>
                 <needLevelOffset>1.00</needLevelOffset>
                 <listOrder>1012</listOrder>
@@ -130,12 +128,6 @@
         </comps>
         <tickerType>Rare</tickerType>
     </ThingDef>
-
-    <ChemicalDef>
-        <defName>Blood</defName>
-        <label>Blood</label>
-        <canBinge>false</canBinge>
-    </ChemicalDef>
 
     <RecipeDef ParentName="SurgeryFlesh">
         <defName>DonateBlood</defName>


### PR DESCRIPTION
ChemicalDefs without addictionhediff may break worldgen if faction leader errors during pawngen as a reult of null hediff. Since the Blood chemical def doesn't do anything, I've removed it. See also: penoxy.

https://gist.github.com/HugsLibRecordKeeper/0c2219d20035bce668f680cb2d09e1d8#file-output_log-txt-L1677